### PR TITLE
move auth to token resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In order to succsfully call endpoints you need the following:
 
   ```
   POST    /api/users
-  POST    /api/users/sign-in
+  POST    /api/tokens
   GET     /api/users
   GET     /api/users/:id
   PATCH   /api/users/:id
@@ -37,7 +37,7 @@ In order to succsfully call endpoints you need the following:
 In order to authenticate yourself with the server you should do the following:
 
   * Register a new user `POST /users` including a bcrypt hashed password
-  * do a POST request to `/api/users/sign-in` with `email` and `password` params
+  * do a POST request to `/api/tokens` with `email` or `username` and `password` params
   * if the login was succesful the server returns your `token`
 
 ## Learn more

--- a/lib/kidsee_api/accounts/accounts.ex
+++ b/lib/kidsee_api/accounts/accounts.ex
@@ -57,6 +57,13 @@ defmodule KidseeApi.Accounts do
     Repo.get_by(User, clauses)
   end
 
+  def find_user_by_identification!(string) do
+    Repo.one!(from u in User,
+      where: u.email == ^string,
+      or_where: u.username == ^string
+    )
+  end
+
   @doc """
   Creates a user.
 

--- a/lib/kidsee_api_web/controllers/token_controller.ex
+++ b/lib/kidsee_api_web/controllers/token_controller.ex
@@ -1,0 +1,32 @@
+defmodule KidseeApiWeb.TokenController do
+  use KidseeApiWeb, :controller
+
+  action_fallback KidseeApiWeb.FallbackController
+
+  alias KidseeApi.Accounts
+  alias KidseeApi.Accounts.User
+
+  def create(conn, %{"email" => email, "password" => password}) do
+    render_token(conn, email, password)
+  end
+
+  def create(conn, %{"username" => username, "password" => password}) do
+    render_token(conn, username, password)
+  end
+
+  def create(_conn, params) do
+    fields = %{username: :string, email: :string, password: :string}
+    changeset = {%{}, fields}
+    |> Ecto.Changeset.cast(params, Map.keys(fields))
+    |> Ecto.Changeset.validate_required(Map.keys(fields))
+    {:error, changeset}
+  end
+
+  defp render_token(conn, identification, password) do
+    with %User{} = user <- Accounts.find_user_by_identification!(identification) do
+      with {:ok, token, _claims} <- Accounts.authenticate(%{user: user, password: password}) do
+        render conn, "token.json-api", token: token
+      end
+    end
+  end
+end

--- a/lib/kidsee_api_web/controllers/user_controller.ex
+++ b/lib/kidsee_api_web/controllers/user_controller.ex
@@ -11,17 +11,6 @@ defmodule KidseeApiWeb.UserController do
     render(conn, "index.json-api", data: users)
   end
 
-  def sign_in(conn, %{"email" => email, "password" => password}) do
-    # Find the user in the database based on the credentials sent with the request
-    with %User{} = user <- Accounts.find_user(%{email: email}) do
-      # Attempt to authenticate the user
-      with {:ok, token, _claims} <- Accounts.authenticate(%{user: user, password: password}) do
-        # Render the token
-        render conn, "token.json-api", token: token
-      end
-    end
-  end
-
   def create(conn, %{"data" => data}) do
     attrs = JaSerializer.Params.to_attributes(data)
     with {:ok, %User{} = user} <- Accounts.create_user(attrs) do

--- a/lib/kidsee_api_web/router.ex
+++ b/lib/kidsee_api_web/router.ex
@@ -15,7 +15,7 @@ defmodule KidseeApiWeb.Router do
     pipe_through :api
 
     resources "/users", UserController, only: [:create]
-    post "/users/sign-in", UserController, :sign_in
+    post "/tokens", TokenController, :create
   end
 
   scope "/api", KidseeApiWeb do

--- a/lib/kidsee_api_web/views/token_view.ex
+++ b/lib/kidsee_api_web/views/token_view.ex
@@ -1,0 +1,7 @@
+defmodule KidseeApiWeb.TokenView do
+  use KidseeApiWeb, :view
+
+  def render("token.json-api", %{token: token}) do
+    %{meta: %{token: token}}
+  end
+end

--- a/lib/kidsee_api_web/views/user_view.ex
+++ b/lib/kidsee_api_web/views/user_view.ex
@@ -9,8 +9,4 @@ defmodule KidseeApiWeb.UserView do
     :city,
     :avatar
   ]
-
-  def render("token.json-api", %{token: token}) do
-    %{token: token}
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KidseeApi.Mixfile do
   def project do
     [
       app: :kidsee_api,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env),
       compilers: [:phoenix, :gettext] ++ Mix.compilers,

--- a/test/kidsee_api_web/controllers/token_controller_test.exs
+++ b/test/kidsee_api_web/controllers/token_controller_test.exs
@@ -1,0 +1,36 @@
+defmodule KidseeApiWeb.TokenControllerTest do
+  use KidseeApiWeb.ConnCase do
+    use KidseeApi.Factory
+  end
+
+  describe "create" do
+    setup do [user: insert(:user)] end
+
+    test "renders a token when the email and password are valid", %{conn: conn, user: user} do
+      login = %{email: user.email, password: "test123"}
+      conn = post conn, token_path(conn, :create), login
+
+      assert %{"token" => token} = json_response(conn, 200)["meta"]
+      assert {:ok, _claims} = KidseeApiWeb.Guardian.decode_and_verify(token)
+    end
+
+    test "renders a token when the username and password are valid", %{conn: conn, user: user} do
+      login = %{username: user.username, password: "test123"}
+      conn = post conn, token_path(conn, :create), login
+
+      assert %{"token" => token} = json_response(conn, 200)["meta"]
+      assert {:ok, _claims} = KidseeApiWeb.Guardian.decode_and_verify(token)
+    end
+
+    test "renders not found if the login was not valid", %{conn: conn} do
+      assert_error_sent 404, fn ->
+        post conn, token_path(conn, :create), %{email: "bla", password: "bla"}
+      end
+    end
+
+    test "renders errors if params are missing", %{conn: conn} do
+      conn = post conn, token_path(conn, :create), %{}
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+end


### PR DESCRIPTION
* renamed sign-in to /tokens endpoint
  * returns `{meta: {token: <token>}}`
  * added option to login with email or username
  * better error handling
  * separated from users
  * added tests